### PR TITLE
Add wiki index generation and update project settings

### DIFF
--- a/app/program.py
+++ b/app/program.py
@@ -5,7 +5,6 @@ from app.context import AppContext
 from app.project import PapyrusProject
 from app.publishing import Sort
 
-
 # Project
 #---------------------------------------------
 
@@ -86,5 +85,16 @@ def start(context:AppContext) -> None:
     else:
         logging.info(f"Found {len(context.projects)} projects.")
 
+    # Generate wiki pages for each project.
     for key in context.projects:
         project_start(context, context.projects[key])
+
+    # Generate the wiki index page.
+    index_path = os.path.join(context.base_directory, "wiki", "Papyrus", "Scripts", "index.wiki")
+    if not os.path.exists(os.path.dirname(index_path)):
+        os.makedirs(os.path.dirname(index_path))
+        logging.debug(f"Created index directory: {os.path.dirname(index_path)}")
+    try:
+        wiki.index.write(context, index_path)
+    except Exception as e:
+        logging.error(f"Failed to write projects index: {str(e)}")

--- a/app/wiki/__init__.py
+++ b/app/wiki/__init__.py
@@ -1,3 +1,4 @@
 from . import style # type: ignore # noqa: F401
 from . import page # type: ignore # noqa: F401
 from . import template # type: ignore # noqa: F401
+from . import index # type: ignore # noqa: F401

--- a/app/wiki/index.py
+++ b/app/wiki/index.py
@@ -1,0 +1,128 @@
+from collections import Counter
+from collections.abc import ItemsView
+from typing import TextIO
+from app.context import AppContext
+from app.project import PapyrusProject
+
+
+# Information
+#---------------------------------------------
+
+def statistics_project(project:PapyrusProject) -> \
+    tuple[int, int, Counter[str], Counter[str]]:
+    # Initialize count trackers
+    script_extends_counter:Counter[str] = Counter()
+    script_member_kind_counter:Counter[str] = Counter()
+
+    # Iterate through each script to count each use of extends
+    for script in project.scripts:
+        script_name:str = script.header.extends.value
+        if not script_name: script_name = "ScriptObject"
+        script_extends_counter[script_name] += 1
+
+        # Iterate through each member in the script to count their kinds
+        for member in script.members:
+            script_member_kind_counter[member.kind] += 1
+
+    return (
+        len(project.imports),
+        len(project.scripts),
+        script_extends_counter,
+        script_member_kind_counter
+    )
+
+
+# MediaWiki
+#---------------------------------------------
+
+def wiki_list_project_imports(project:PapyrusProject):
+    return ", ".join(project.imports) if project.imports else "Nothing"
+
+
+def wiki_list_member_kinds(script_member_kind_counter:Counter[str]) -> str:
+    kinds:ItemsView[str, int] = script_member_kind_counter.items()
+    if not kinds:
+        return "There are no members defined in this project."
+    entries:list[str] = []
+    for kind, count in kinds:
+        entries.append(f"* {kind} was used {count} times.")
+    return "\n".join(entries)
+
+
+def wiki_list_extends_most_common(script_extends_counter:Counter[str]) -> str:
+    common_parent_names:list[tuple[str, int]] = script_extends_counter.most_common(3)
+    if not common_parent_names:
+        return "There are no common scripts in this project."
+    entries:list[str] = []
+    for script_name, count in common_parent_names:
+        entries.append(f"* The {script_name} script was extended {count} times.")
+    return "\n".join(entries)
+
+
+def wiki_list_script_names(project:PapyrusProject) -> str:
+    if not project.scripts:
+        return "There are no scripts defined in this project."
+    entries:list[str] = []
+    for script in project.scripts:
+        entries.append(f"* {str(script.header.name)}")
+    return "\n".join(entries)
+
+
+# Write
+#---------------------------------------------
+
+def write_section(file:TextIO, project:PapyrusProject) -> None:
+    ( # Collect information for this project
+        project_imports_count,
+        project_scripts_count,
+        script_extends_counter,
+        script_member_kind_counter
+    ) = statistics_project(project)
+
+    # Add project summary information
+    file.write(f"== {project.identifier} ==\n")
+    file.write(f"* Imports: {project_imports_count} ({wiki_list_project_imports(project)})\n")
+    file.write(f"* Scripts: {project_scripts_count}\n")
+    file.write("\n")
+
+    # Add script member statistics section
+    file.write("==== Member Statistics ====\n")
+    if project_scripts_count:
+        file.write(f"This project overall contains {script_member_kind_counter.total()} total members spread over {project_scripts_count} scripts.\n")
+        file.write(wiki_list_member_kinds(script_member_kind_counter)+"\n")
+    else:
+        file.write("There are no scripts defined in this project, so no member statistics can be provided.\n")
+    file.write("\n")
+
+    # Add script inheritance statistics section
+    file.write("==== Inheritance Statistics ====\n")
+    if project_scripts_count:
+        file.write(f"The most common extended parent scripts:\n")
+        file.write(wiki_list_extends_most_common(script_extends_counter)+"\n")
+    else:
+        file.write("There are no scripts defined in this project, so no inheritance statistics can be provided.\n")
+    file.write("\n")
+
+    # List script statistics section
+    file.write("\n")
+    file.write("==== Scripts ====\n")
+    if project_scripts_count:
+        file.write(f"There are {project_scripts_count} scripts that belong to this project:\n")
+        file.write(wiki_list_script_names(project))
+    else:
+        file.write("There are no scripts defined in this project.\n")
+    file.write("\n")
+
+
+def write(context:AppContext, output_file_path:str) -> None:
+    with open(output_file_path, "w", encoding="utf-8") as file:
+        # Write the wiki page header.
+        file.write("= Projects =\n")
+        file.write("This page lists all Papyrus project information for each import.\n")
+        file.write("\n\n")
+
+        # Write each project wiki section.
+        for identifier in context.projects:
+            project:PapyrusProject = context.projects[identifier]
+            write_section(file, project)
+            file.write("\n\n")

--- a/app_settings.json
+++ b/app_settings.json
@@ -28,10 +28,10 @@
 			"output.members": false
 		},
 		{
-			"identifier": "Base-Default-Common",
+			"identifier": "Base-Shared-Default",
 			"source.imports": [ "Base-Native" ],
-			"source.directory": "_input/Papyrus/Base-Default-Common",
-			"output.directory": "wiki/Papyrus/Scripts/Base-Default-Common",
+			"source.directory": "_input/Papyrus/Base-Shared-Default",
+			"output.directory": "wiki/Papyrus/Scripts/Base-Shared-Default",
 			"output.enabled": true,
 			"output.sort": "DEFAULT",
 			"output.objects": true,
@@ -39,7 +39,7 @@
 		},
 		{
 			"identifier": "Base-Default",
-			"source.imports": [ "Base-Default-Common", "Base-Native" ],
+			"source.imports": [ "Base-Shared-Default", "Base-Native" ],
 			"source.directory": "_input/Papyrus/Base-Default",
 			"output.directory": "wiki/Papyrus/Scripts/Base-Default",
 			"output.enabled": true,


### PR DESCRIPTION
Introduces app/wiki/index.py to generate a MediaWiki index page summarizing Papyrus projects, including statistics and script listings. Updates app/program.py to call the new index writer after processing projects. Modifies app_settings.json to rename 'Base-Default-Common' to 'Base-Shared-Default' and updates related import and directory paths. Also updates __init__.py to import the new index module.