### PR TITLE
Refactor Papyrus compiler path to workspace setting

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,9 +6,9 @@
         {
             "label": "Base-Native (Assemble)",
             "type": "shell",
-            "command": "\"C:\\Program Files (x86)\\Steam\\steamapps\\common\\Starfield\\Tools\\Papyrus Compiler\\PapyrusCompiler.exe\"",
+            "command": "\"${config:papyrus.compiler.path}\"",
             "args": [
-                "${workspaceFolder}\\wiki\\import\\Test-Sample\\Test-Sample.ppj"
+                "${workspaceFolder}\\wiki\\import\\Base-Native\\Base-Native.ppj"
             ],
             "group": {
                 "kind": "build"
@@ -18,7 +18,7 @@
         {
             "label": "Base-Shared-Default (Assemble)",
             "type": "shell",
-            "command": "\"C:\\Program Files (x86)\\Steam\\steamapps\\common\\Starfield\\Tools\\Papyrus Compiler\\PapyrusCompiler.exe\"",
+            "command": "\"${config:papyrus.compiler.path}\"",
             "args": [
                 "${workspaceFolder}\\wiki\\import\\Base-Shared-Default\\Base-Shared-Default.ppj"
             ],
@@ -30,7 +30,7 @@
         {
             "label": "Base-Default (Assemble)",
             "type": "shell",
-            "command": "\"C:\\Program Files (x86)\\Steam\\steamapps\\common\\Starfield\\Tools\\Papyrus Compiler\\PapyrusCompiler.exe\"",
+            "command": "\"${config:papyrus.compiler.path}\"",
             "args": [
                 "${workspaceFolder}\\wiki\\import\\Base-Default\\Base-Default.ppj"
             ],
@@ -42,7 +42,7 @@
         {
             "label": "Test-Sample (Assemble)",
             "type": "shell",
-            "command": "\"C:\\Program Files (x86)\\Steam\\steamapps\\common\\Starfield\\Tools\\Papyrus Compiler\\PapyrusCompiler.exe\"",
+            "command": "\"${config:papyrus.compiler.path}\"",
             "args": [
                 "${workspaceFolder}\\wiki\\import\\Test-Sample\\Test-Sample.ppj"
             ],

--- a/README.md
+++ b/README.md
@@ -4,6 +4,22 @@ Some automation for https://starfieldwiki.net/ MediaWiki contributions.
 - [Reference for Script Objects](https://starfieldwiki.net/wiki/Starfield_Mod:Object_Scripts)
 - [Reference for Editor Objects](https://starfieldwiki.net/wiki/Starfield_Mod:Form_Reference)
 
+
+### VS Code: Workspace Settings
+The VS Code build tasks use the `${config:papyrus.compiler.path}` setting to compile imported scripts into Papyrus assembly.
+This is done to ensure the compiler import dependencies are valid for each Papyrus project.
+Create a new `*.code-workspace` on the root directory and add the following setting.
+Avoid committing your own local `papyrus.compiler.path` setting to the repository.
+```json
+{
+  "settings":
+  {
+    "papyrus.compiler.path": "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Starfield\\Tools\\Papyrus Compiler\\PapyrusCompiler.exe"
+  }
+}
+```
+
+
 ### TODO
 - TODO: Remove all `# TODO:` from the project by doing them or migrating them to an issue tracker.
 - Wiki: Finialize the output file structure and naming conventions.


### PR DESCRIPTION
- Updated VS Code tasks to use the `${config:papyrus.compiler.path}` setting instead of a hardcoded compiler path.
- Added documentation to the README explaining how to configure the Papyrus compiler path in a workspace file for local development.